### PR TITLE
fix dragstart behavior

### DIFF
--- a/main.js
+++ b/main.js
@@ -117,7 +117,8 @@ function drawGraph() {
 }
 
 function dragstarted(event, d) {
-  if (!event.active) d.fx = d.x, d.fy = d.y;
+  d.fx = d.x;
+  d.fy = d.y;
 }
 function dragged(event, d) {
   d.fx = event.x;


### PR DESCRIPTION
## Summary
- always pin node position when drag starts

## Testing
- `python3 -m http.server 8000` *(fails: can't verify in browser)*

------
https://chatgpt.com/codex/tasks/task_e_683fe21cdc2c8328ab1fd6a7f4c79e74