### PR TITLE
Handle multiple graph simulations

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ async function loadData() {
 let selectedLayer = 'all';
 let nodes = [];
 let links = [];
+let simulation;
 
 function filterNodes(nodes, layer) {
   if(layer === 'all') return nodes;
@@ -36,6 +37,9 @@ function filterLinks(links, layer) {
 
 function drawGraph() {
   d3.select('#diagram').selectAll('*').remove();
+  if (simulation) {
+    simulation.stop();
+  }
   const width = 1100, height = 700;
   const svg = d3.select('#diagram')
     .attr('width', width)
@@ -62,7 +66,7 @@ function drawGraph() {
     target: l.target.id || l.target
   }));
 
-  const simulation = d3.forceSimulation(filteredNodes)
+  simulation = d3.forceSimulation(filteredNodes)
     .force('link', d3.forceLink(simLinks).id(d => d.id).distance(220))
     .force('charge', d3.forceManyBody().strength(-630))
     .force('center', d3.forceCenter(width / 2, height / 2));


### PR DESCRIPTION
## Summary
- make `simulation` global so it can be reused
- stop existing simulation before creating a new one in `drawGraph`

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683fe45ce7048328aabef5d19f4a6d2c