### PR TITLE
Fix drawGraph to align with codex version

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,9 +35,6 @@ function filterLinks(nodeList, linkList, layer) {
 
 function drawGraph() {
   d3.select('#diagram').selectAll('*').remove();
-  if (simulation) {
-    simulation.stop();
-  }
   const width = 1100, height = 700;
   const svg = d3.select('#diagram')
     .attr('width', width)


### PR DESCRIPTION
## Summary
- remove `simulation.stop()` call from `drawGraph`

## Testing
- `node tests/utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683ff9eb67b88328aaac48946dcdb225