### PR TITLE
Fix drag handler regression and restore tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -141,7 +141,12 @@ function dragstarted(event, d) {
   d.fy = d.y;
 }
 function dragged(event, d) {
-
+  d.fx = Math.max(0, Math.min(WIDTH, event.x));
+  d.fy = Math.max(0, Math.min(HEIGHT, event.y));
+}
+function dragended(event, d) {
+  if (!event.active && simulation) {
+    simulation.alphaTarget(0).restart();
   }
   d.fx = null;
   d.fy = null;
@@ -225,6 +230,8 @@ if (typeof module !== 'undefined') {
     filterNodes,
     filterLinks,
     findLayer,
+    WIDTH,
+    HEIGHT,
 
     // exported for tests
     dragstarted,

--- a/tests/dragHandlers.test.js
+++ b/tests/dragHandlers.test.js
@@ -1,8 +1,9 @@
-
+const { dragstarted, dragged, dragended, __setSimulation, WIDTH, HEIGHT } = require('../main');
 
 class FakeSimulation {
   constructor() {
     this._alphaTarget = 0;
+    this.restarted = false;
     this._nodes = [{ id: 'n1' }];
   }
   nodes() { return this._nodes; }
@@ -25,11 +26,15 @@ test('drag handlers keep simulation responsive', () => {
   // start drag
   dragstarted({ active: 0 }, node);
   expect(sim.alphaTarget()).toBeGreaterThan(0);
-
+  expect(sim.restarted).toBe(true);
+  // simulate some movement with out-of-bounds position
+  dragged({ x: WIDTH + 100, y: HEIGHT + 50 }, node);
+  expect(node.fx).toBeLessThanOrEqual(WIDTH);
+  expect(node.fy).toBeLessThanOrEqual(HEIGHT);
   // end drag
   dragended({ active: 0 }, node);
   expect(sim.alphaTarget()).toBe(0);
   expect(node.fx).toBeNull();
   expect(node.fy).toBeNull();
-
+  expect(sim.restarted).toBe(true);
 });


### PR DESCRIPTION
## Summary
- restore missing drag handler logic removed by merge
- export graph dimensions for tests
- update drag handler tests with imports and clamped movement check

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840659d5e848328a513e514fc6956b9